### PR TITLE
Make transaction details optional

### DIFF
--- a/src/ofxstatement/plugins/mt940.py
+++ b/src/ofxstatement/plugins/mt940.py
@@ -115,7 +115,7 @@ class Parser(BaseStatementParser):
         # Use str() to prevent rounding errors
         bank_account_to = transaction.data.get('customer_reference')
         amount = Decimal(str(transaction.data['amount'].amount))
-        memo = transaction.data['transaction_details']
+        memo = transaction.data['transaction_details'] if 'transaction_details' in transaction.data else transaction.data['purpose'] if 'purpose' in transaction.data else ''
         memo = memo.replace("\n", '')
         memo = memo.replace(transaction.data['customer_reference'], '', 1)
         memo = memo.replace(transaction.data['extra_details'], '', 1).strip()

--- a/tests/test_mt940.py
+++ b/tests/test_mt940.py
@@ -201,6 +201,38 @@ class ParserTest(TestCase):
         self.assertEqual(statement_line.memo, 'Some details')
         self.assertEqual(statement_line.payee, 'Jane Doe (1234)')
 
+    def test_parse_record_parses_transaction_with_only_mandatory_data(self):
+        transaction = Transaction(None)
+        transaction.update({
+            'customer_reference': '1234',
+            'extra_details': 'Jane Doe',
+            'amount': Amount('42', 'D'),
+            'date': datetime(2022, 2, 2).date(),
+        })
+
+        parser = Parser('', '', '')
+        statement_line = parser.parse_record(transaction)
+
+        self.assertEqual(statement_line.amount, Decimal('-42.00'))
+        self.assertEqual(statement_line.date, datetime.strptime("2022-02-02", parser.date_format).date())
+        self.assertEqual(statement_line.memo, 'UNKNOWN')
+        self.assertEqual(statement_line.payee, 'Jane Doe (1234)')
+
+    def test_parse_record_uses_purpose_if_given_and_transaction_details_are_missing(self):
+        transaction = Transaction(None)
+        transaction.update({
+            'customer_reference': '1234',
+            'extra_details': 'Jane Doe',
+            'amount': Amount('42', 'D'),
+            'purpose': 'Some purpose',
+            'date': datetime(2022, 2, 2).date(),
+        })
+
+        parser = Parser('', '', '')
+        statement_line = parser.parse_record(transaction)
+
+        self.assertEqual(statement_line.memo, 'Some purpose')
+
     def test_parse_record_removes_payee_from_memo(self):
         transaction = Transaction(None)
         transaction.update({

--- a/tests/test_mt940.py
+++ b/tests/test_mt940.py
@@ -8,8 +8,15 @@ import pytest
 from ofxstatement.plugins.mt940 import Plugin, get_bank_id
 from ofxstatement.exceptions import ValidationError
 
+from mt940.models import Transaction
+from mt940.models import Amount
+
+from src.ofxstatement.plugins.mt940 import Parser
+
 
 class ParserTest(TestCase):
+
+    # Integration tests:
 
     def test_ASN(self):
         # Create and configure parser:
@@ -173,3 +180,53 @@ class ParserTest(TestCase):
 
         # And parse:
         parser.parse().assert_valid()
+
+    # Unit tests:
+
+    def test_parse_record_parses_transaction_with_full_set_of_data(self):
+        transaction = Transaction(None)
+        transaction.update({
+            'customer_reference': '1234',
+            'extra_details': 'Jane Doe',
+            'amount': Amount('42', 'D'),
+            'transaction_details': 'Some details',
+            'date': datetime(2022, 2, 2).date(),
+        })
+
+        parser = Parser('', '', '')
+        statement_line = parser.parse_record(transaction)
+
+        self.assertEqual(statement_line.amount, Decimal('-42.00'))
+        self.assertEqual(statement_line.date, datetime.strptime("2022-02-02", parser.date_format).date())
+        self.assertEqual(statement_line.memo, 'Some details')
+        self.assertEqual(statement_line.payee, 'Jane Doe (1234)')
+
+    def test_parse_record_removes_payee_from_memo(self):
+        transaction = Transaction(None)
+        transaction.update({
+            'customer_reference': '1234',
+            'extra_details': 'Jane Doe',
+            'amount': Amount('42', 'D'),
+            'transaction_details': 'Some details Jane Doe 1234',
+            'date': datetime(2022, 2, 2).date(),
+        })
+
+        parser = Parser('', '', '')
+        statement_line = parser.parse_record(transaction)
+
+        self.assertEqual(statement_line.memo, 'Some details')
+
+    def test_parse_record_skips_zero_value_transactions(self):
+        transaction = Transaction(None)
+        transaction.update({
+            'customer_reference': '1234',
+            'extra_details': 'Jane Doe',
+            'amount': Amount('0', 'C'),
+            'transaction_details': 'Some details',
+            'date': datetime(2022, 2, 2).date(),
+        })
+
+        parser = Parser('', '', '')
+        statement_line = parser.parse_record(transaction)
+
+        self.assertIsNone(statement_line)


### PR DESCRIPTION
A few weeks ago, I had problems using this because the key `transaction_details` was missing. I dirtily hacked a solution by hacking the python scripts in my installation, but I planned to properly commit it back upstream. For doing so, I wrote some unit tests.

I now realised that in the meantime, an issue and a PR have already been created for this (#3). However, I decided to PR this anyway, because I also made unit tests for my fix.

Also, my fix uses the field "purpose" for the memo in case "transaction_details" are missing (which is what my bank provides, and it seems to contain what you'd expect a memo to contain).

Please merge only after #4 has been merged.

Fixes #2.